### PR TITLE
Add Arch Linux support and improve Linux setup docs

### DIFF
--- a/Linux2BNMV/README.md
+++ b/Linux2BNMV/README.md
@@ -12,13 +12,30 @@ You'll need two things from your PC setup: `run-bnmv-stream.sh` and
 
 ## What you need
 
-- **PC**: Linux with PulseAudio or PipeWire (KDE Neon has this by default),
-  Python 3, and the `pulseaudio-utils` package (provides `pactl` and
-  `parec`).
+- **PC**: Linux with PulseAudio or PipeWire, Python 3, and the
+  `pulseaudio-utils` package (provides `pactl` and `parec`).
 - **Phone**: BNMV installed, connected to **the same Wi-Fi network** as your
   PC.
-- A way to send BNMV a one-time "connect" command — see **Step 3** below for
-  two easy options.
+- A way to send BNMV a one-time "connect" command — see **Step 3** below.
+
+### Distro-specific dependencies
+
+| Distro | Install command |
+|---|---|
+| **Debian / Ubuntu / KDE Neon** | `sudo apt install pulseaudio-utils python3-venv` |
+| **Arch Linux** | `sudo pacman -S python python-pipewire` (or `python-pulseaudio` if you use PulseAudio) |
+| **Fedora** | `sudo dnf install pulseaudio-utils python3` |
+
+> **Note:** On Arch Linux and other distros that mark their Python as
+> [externally managed (PEP 668)](https://peps.python.org/pep-0668/),
+> `pip install --user` will fail. The script handles this automatically by
+> creating a local virtual environment (`.venv/`). If you prefer to set it up
+> manually first:
+> ```bash
+> python -m venv .venv
+> source .venv/bin/activate.fish   # or: source .venv/bin/activate (bash)
+> pip install numpy
+> ```
 
 ---
 
@@ -34,7 +51,7 @@ You'll need two things from your PC setup: `run-bnmv-stream.sh` and
    ./run-bnmv-stream.sh
    ```
 
-The first run may install the `numpy` Python package automatically if it's
+The first run will install the `numpy` Python package automatically if it's
 missing. Once running, you'll see something like:
 
 ```
@@ -49,7 +66,6 @@ missing. Once running, you'll see something like:
 [bnmv] Listening for latency pings on UDP :8890 ...
 ```
 
-
 ---
 
 ## Step 2: Make sure your phone is on the same network
@@ -59,30 +75,44 @@ Wi-Fi network as your PC. This won't work over mobile data, and it usually
 won't work on "guest" Wi-Fi networks, since those often block devices from
 talking to each other (client isolation).
 
+---
 
-## Step 3: Confirm it's working
+## Step 3: Connect from BNMV
 
-- On the client device, connect to the linux pc with the `Another device or app...` audio source.
-- On the PC, the terminal should show a handshake line and keep running
-  silently after that (that's normal — it's streaming continuously).
-- On the phone, open BNMV and confirm the visualizer is reacting to your
-  PC's audio. If BNMV doesn't automatically switch to the network source,
-  check its settings for a source selector and choose the network/external
-  option.
-- Play something on your PC and watch the visualizer respond.
+Open BNMV on your phone and use the **External Audio / Another device or
+app...** option to connect to your PC using its LAN IP and port `8888`.
+
+On the PC, the terminal should show a handshake line and keep running
+silently after that (that's normal — it's streaming continuously).
+
+On the phone, confirm the visualizer is reacting to your PC's audio.
+
+---
+
+## Step 4: Open your firewall (if needed)
+
+If your PC has a firewall enabled, you need to allow BNMV's UDP ports.
+
+**ufw** (Debian / Ubuntu / Arch):
+```bash
+sudo ufw allow 8888:8891/udp
+```
+
+**firewalld** (Fedora / RHEL):
+```bash
+sudo firewall-cmd --add-port=8888-8891/udp --permanent
+sudo firewall-cmd --reload
+```
 
 ---
 
 ## Troubleshooting
 
-**Nothing happens after sending the connect command**
+**Nothing happens after connecting from BNMV**
 - Double-check the PC's LAN IP hasn't changed (Wi-Fi/router restarts can
   reassign it) — re-check the IP printed by `run-bnmv-stream.sh`.
 - Confirm phone and PC are genuinely on the same network/subnet.
-- Check your PC's firewall isn't blocking UDP ports `8888`–`8891`:
-  ```bash
-  sudo ufw allow 8888:8891/udp
-  ```
+- Make sure your firewall allows UDP ports `8888`–`8891` (see Step 4).
 
 **Visualizer connects but shows no audio movement**
 - Make sure audio is actually playing on the PC through the **default**
@@ -101,11 +131,11 @@ talking to each other (client isolation).
   ```
 
 **I switched Wi-Fi networks or restarted my PC**
-- You'll need to repeat Step 3 (send the connect command again), since
+- You'll need to repeat Step 3 (reconnect from BNMV), since
   BNMV needs to be told the PC's current IP each time it changes.
 
 ---
 
-That's itw once connected, just leave `run-bnmv-stream.sh` running in the
+That's it — once connected, just leave `run-bnmv-stream.sh` running in the
 background on your PC whenever you want your phone's visualizer synced to
 your computer's audio.

--- a/Linux2BNMV/run-bnmv-stream.sh
+++ b/Linux2BNMV/run-bnmv-stream.sh
@@ -36,17 +36,50 @@ command -v parec    >/dev/null 2>&1 || missing+=("pulseaudio-utils / pipewire-pu
 if [ ${#missing[@]} -ne 0 ]; then
     echo "Missing required tools:" >&2
     printf '  - %s\n' "${missing[@]}" >&2
-    echo "On KDE Neon: sudo apt install pulseaudio-utils" >&2
+    echo "Debian/Ubuntu: sudo apt install pulseaudio-utils python3-venv" >&2
+    echo "Arch:          sudo pacman -S python pipewire-pulse (or pulseaudio)" >&2
+    echo "Fedora:        sudo dnf install pulseaudio-utils python3" >&2
     exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# 2. Ensure numpy is available (use a venv if the system is PEP 668 managed
+#    or if --user install fails)
+# ---------------------------------------------------------------------------
+VENV_DIR="$SCRIPT_DIR/.venv"
+
 if ! python3 -c "import numpy" >/dev/null 2>&1; then
-    echo "Python 'numpy' not found. Installing for your user..."
-    pip3 install --user numpy
+    echo "Python 'numpy' not found. Attempting install..."
+
+    # Try a simple --user install first (works on Debian/Ubuntu/Fedora)
+    if pip3 install --user numpy 2>/dev/null; then
+        echo "numpy installed via pip --user."
+    elif [ ! -d "$VENV_DIR" ]; then
+        # PEP 668 distros (Arch, Fedora 40+, etc.) block --user installs.
+        # Fall back to a local virtual environment.
+        echo "Creating virtual environment in $VENV_DIR ..."
+        python3 -m venv "$VENV_DIR"
+        "$VENV_DIR/bin/pip" install numpy
+        echo "numpy installed in venv."
+    elif [ -d "$VENV_DIR" ]; then
+        "$VENV_DIR/bin/pip" install numpy
+        echo "numpy installed in existing venv."
+    else
+        echo "ERROR: Could not install numpy. Install it manually:" >&2
+        echo "  python3 -m venv $VENV_DIR && $VENV_DIR/bin/pip install numpy" >&2
+        exit 1
+    fi
+fi
+
+# Use venv python if it exists, otherwise fall back to system python3
+if [ -x "$VENV_DIR/bin/python" ]; then
+    PYTHON="$VENV_DIR/bin/python"
+else
+    PYTHON="python3"
 fi
 
 # ---------------------------------------------------------------------------
-# 2. Find the monitor source for the default sink (i.e. "what's playing")
+# 3. Find the monitor source for the default sink (i.e. "what's playing")
 # ---------------------------------------------------------------------------
 DEFAULT_SINK="$(pactl get-default-sink)"
 MONITOR_SOURCE="${DEFAULT_SINK}.monitor"
@@ -59,7 +92,7 @@ if ! pactl list short sources | grep -q "^[0-9]*[[:space:]]*${MONITOR_SOURCE}[[:
 fi
 
 # ---------------------------------------------------------------------------
-# 3. Figure out and print this machine's LAN IP, for the phone-side config
+# 4. Figure out and print this machine's LAN IP, for the phone-side config
 # ---------------------------------------------------------------------------
 LAN_IP="$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}')"
 echo "=================================================================="
@@ -71,7 +104,7 @@ echo " Point BNMV's ACTION_CONNECT_UDP intent at that ip:port from your phone."
 echo "=================================================================="
 
 # ---------------------------------------------------------------------------
-# 4. Parse a few passthrough options, then hand off to the Python streamer
+# 5. Parse a few passthrough options, then hand off to the Python streamer
 # ---------------------------------------------------------------------------
 EXTRA_ARGS=()
 SOURCE="$MONITOR_SOURCE"
@@ -87,4 +120,4 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-exec python3 "$PY_SCRIPT" --source "$SOURCE" "${EXTRA_ARGS[@]}"
+exec "$PYTHON" "$PY_SCRIPT" --source "$SOURCE" "${EXTRA_ARGS[@]}"


### PR DESCRIPTION
## Changes

### `run-bnmv-stream.sh`
- Automatically falls back to a local `.venv/` when `pip install --user` fails (PEP 668 distros like Arch Linux, Fedora 40+)
- Updated dependency error message to show install commands for Debian, Arch, and Fedora

### `Linux2BNMV/README.md`
- Added distro-specific dependency table (Debian/Ubuntu, Arch, Fedora)
- Added note about PEP 668 and automatic venv creation with manual setup commands
- Restructured Step 3 to use the BNMV app's built-in UI instead of Tasker
- Added **Step 4: Open your firewall** with `ufw` and `firewalld` commands

## Why

Running the script on Arch Linux fails immediately because Arch marks its Python as [externally managed (PEP 668)](https://peps.python.org/pep-0668/), blocking `pip install --user`. The firewall also silently drops BNMV's UDP handshake packets. Both issues are common on Arch/Fedora and not documented anywhere.